### PR TITLE
add hermes-agents helm chart

### DIFF
--- a/charts/hermes-agents/Chart.yaml
+++ b/charts/hermes-agents/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: hermes-agents
+description: A Helm chart for Hermes Agent by Nous Research
+type: application
+version: 0.1.0
+appVersion: "latest"
+sources:
+  - https://github.com/NousResearch/hermes-agent
+home: https://hermes-agent.nousresearch.com

--- a/charts/hermes-agents/templates/_helpers.tpl
+++ b/charts/hermes-agents/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hermes-agents.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "hermes-agents.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hermes-agents.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "hermes-agents.labels" -}}
+helm.sh/chart: {{ include "hermes-agents.chart" . }}
+{{ include "hermes-agents.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "hermes-agents.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "hermes-agents.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Name of the PVC to use for /opt/data.
+*/}}
+{{- define "hermes-agents.pvcName" -}}
+{{- if .Values.persistence.existingClaim }}
+{{- .Values.persistence.existingClaim }}
+{{- else }}
+{{- printf "%s-data" (include "hermes-agents.fullname" .) }}
+{{- end }}
+{{- end }}

--- a/charts/hermes-agents/templates/deployment.yaml
+++ b/charts/hermes-agents/templates/deployment.yaml
@@ -32,33 +32,6 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if and .Values.auth.seed.enabled .Values.auth.seed.existingSecret }}
-      initContainers:
-        - name: seed-auth
-          image: "{{ .Values.auth.seed.image.repository }}:{{ .Values.auth.seed.image.tag }}"
-          imagePullPolicy: {{ .Values.auth.seed.image.pullPolicy }}
-          command:
-            - sh
-            - -c
-            - |
-              set -eu
-              for f in /seed/*; do
-                [ -e "$f" ] || continue
-                name=$(basename "$f")
-                if [ -e "/opt/data/$name" ]; then
-                  echo "skip /opt/data/$name (exists)"
-                else
-                  echo "seed /opt/data/$name"
-                  cp "$f" "/opt/data/$name"
-                fi
-              done
-          volumeMounts:
-            - name: data
-              mountPath: /opt/data
-            - name: auth-seed
-              mountPath: /seed
-              readOnly: true
-      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -101,11 +74,6 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
-        {{- if and .Values.auth.seed.enabled .Values.auth.seed.existingSecret }}
-        - name: auth-seed
-          secret:
-            secretName: {{ .Values.auth.seed.existingSecret }}
-        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/hermes-agents/templates/deployment.yaml
+++ b/charts/hermes-agents/templates/deployment.yaml
@@ -1,0 +1,120 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "hermes-agents.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hermes-agents.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "hermes-agents.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "hermes-agents.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if and .Values.auth.seed.enabled .Values.auth.seed.existingSecret }}
+      initContainers:
+        - name: seed-auth
+          image: "{{ .Values.auth.seed.image.repository }}:{{ .Values.auth.seed.image.tag }}"
+          imagePullPolicy: {{ .Values.auth.seed.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              for f in /seed/*; do
+                [ -e "$f" ] || continue
+                name=$(basename "$f")
+                if [ -e "/opt/data/$name" ]; then
+                  echo "skip /opt/data/$name (exists)"
+                else
+                  echo "seed /opt/data/$name"
+                  cp "$f" "/opt/data/$name"
+                fi
+              done
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+            - name: auth-seed
+              mountPath: /seed
+              readOnly: true
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8642
+              protocol: TCP
+            {{- if .Values.dashboard.enabled }}
+            - name: dashboard
+              containerPort: {{ .Values.service.dashboardPort }}
+              protocol: TCP
+            {{- end }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "hermes-agents.pvcName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- if and .Values.auth.seed.enabled .Values.auth.seed.existingSecret }}
+        - name: auth-seed
+          secret:
+            secretName: {{ .Values.auth.seed.existingSecret }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/hermes-agents/templates/ingress.yaml
+++ b/charts/hermes-agents/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "hermes-agents.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hermes-agents.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "hermes-agents.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/hermes-agents/templates/pvc.yaml
+++ b/charts/hermes-agents/templates/pvc.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "hermes-agents.pvcName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hermes-agents.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/charts/hermes-agents/templates/service.yaml
+++ b/charts/hermes-agents/templates/service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hermes-agents.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hermes-agents.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "hermes-agents.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      protocol: TCP
+      targetPort: http
+    {{- if .Values.dashboard.enabled }}
+    - name: dashboard
+      port: {{ .Values.service.dashboardPort }}
+      protocol: TCP
+      targetPort: dashboard
+    {{- end }}
+{{- end }}

--- a/charts/hermes-agents/values.yaml
+++ b/charts/hermes-agents/values.yaml
@@ -1,0 +1,111 @@
+replicaCount: 1
+
+image:
+  repository: nousresearch/hermes-agent
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# Container command. Hermes documents `gateway run` as the default entrypoint.
+command:
+  - gateway
+  - run
+
+# Environment variables passed to the container. Reference the Hermes docs for
+# the full list (HERMES_DASHBOARD, API_SERVER_*, ANTHROPIC_API_KEY, ...).
+env: []
+  # - name: HERMES_DASHBOARD
+  #   value: "1"
+  # - name: API_SERVER_ENABLED
+  #   value: "true"
+
+# Env vars sourced from existing Secrets or ConfigMaps.
+envFrom: []
+  # - secretRef:
+  #     name: hermes-secrets
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+securityContext: {}
+
+service:
+  enabled: true
+  type: ClusterIP
+  port: 8642
+  # Port the dashboard listens on when HERMES_DASHBOARD=1. Exposed only when
+  # `dashboard.enabled` is true.
+  dashboardPort: 9119
+
+# Set `enabled: true` to also expose the Hermes dashboard via the Service.
+dashboard:
+  enabled: false
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # cert-manager.io/cluster-issuer: letsencrypt
+  hosts:
+    - host: hermes.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+    # - hosts:
+    #     - hermes.example.com
+    #   secretName: hermes-tls
+
+# Persistent storage for /opt/data — the single source of truth for all Hermes
+# state (config, API keys, conversation history, skills, memories).
+persistence:
+  enabled: true
+  # If set, an existing PVC with this name is used instead of creating one.
+  existingClaim: ""
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
+  annotations: {}
+
+# Seed credentials into the PVC on first start. Intended for provisioning the
+# Anthropic OAuth credential (~/.hermes/auth.json) generated locally with
+# `hermes auth add anthropic --type oauth`. The init container copies each key
+# from the Secret to /opt/data/<key> only if the file does not already exist,
+# so OAuth token refreshes that Hermes later writes back to the PVC are
+# preserved across pod restarts.
+#
+# Typical usage to seed an OAuth credential:
+#   1. Run `hermes auth add anthropic --type oauth` locally to populate
+#      ~/.hermes/auth.json.
+#   2. kubectl create secret generic hermes-auth \
+#        --from-file=auth.json=$HOME/.hermes/auth.json
+#   3. Set auth.seed.enabled=true and auth.seed.existingSecret=hermes-auth.
+#
+# For API-key auth, set ANTHROPIC_API_KEY (or OPENAI_API_KEY, ...) via `env` /
+# `envFrom` instead — no seeding required.
+auth:
+  seed:
+    enabled: false
+    existingSecret: ""
+    image:
+      repository: busybox
+      tag: "1.36"
+      pullPolicy: IfNotPresent
+
+resources: {}
+  # limits:
+  #   cpu: 1000m
+  #   memory: 1Gi
+  # requests:
+  #   cpu: 100m
+  #   memory: 256Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/charts/hermes-agents/values.yaml
+++ b/charts/hermes-agents/values.yaml
@@ -63,6 +63,9 @@ ingress:
 
 # Persistent storage for /opt/data — the single source of truth for all Hermes
 # state (config, API keys, conversation history, skills, memories).
+#
+# Run `hermes setup` interactively against the mounted volume to initialise it,
+# e.g. `kubectl exec -it deploy/<release>-hermes-agents -- hermes setup`.
 persistence:
   enabled: true
   # If set, an existing PVC with this name is used instead of creating one.
@@ -72,31 +75,6 @@ persistence:
     - ReadWriteOnce
   size: 10Gi
   annotations: {}
-
-# Seed credentials into the PVC on first start. Intended for provisioning the
-# Anthropic OAuth credential (~/.hermes/auth.json) generated locally with
-# `hermes auth add anthropic --type oauth`. The init container copies each key
-# from the Secret to /opt/data/<key> only if the file does not already exist,
-# so OAuth token refreshes that Hermes later writes back to the PVC are
-# preserved across pod restarts.
-#
-# Typical usage to seed an OAuth credential:
-#   1. Run `hermes auth add anthropic --type oauth` locally to populate
-#      ~/.hermes/auth.json.
-#   2. kubectl create secret generic hermes-auth \
-#        --from-file=auth.json=$HOME/.hermes/auth.json
-#   3. Set auth.seed.enabled=true and auth.seed.existingSecret=hermes-auth.
-#
-# For API-key auth, set ANTHROPIC_API_KEY (or OPENAI_API_KEY, ...) via `env` /
-# `envFrom` instead — no seeding required.
-auth:
-  seed:
-    enabled: false
-    existingSecret: ""
-    image:
-      repository: busybox
-      tag: "1.36"
-      pullPolicy: IfNotPresent
 
 resources: {}
   # limits:


### PR DESCRIPTION
Deploys nousresearch/hermes-agent with a PVC backing /opt/data, a
ClusterIP Service for the gateway (and optional dashboard), and an
ingress that accepts the standard hosts/paths/tls structure.

Supports seeding Anthropic OAuth credentials (auth.json) from a Secret
via an init container that copies them into the PVC only on first
start, so token refreshes Hermes writes back are preserved.