### PR TITLE
Add hermes-agents helm chart (v0.1.1)

### DIFF
--- a/charts/hermes-agents/Chart.yaml
+++ b/charts/hermes-agents/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hermes-agents
 description: A Helm chart for Hermes Agent by Nous Research
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "latest"
 sources:
   - https://github.com/NousResearch/hermes-agent

--- a/charts/hermes-agents/templates/deployment.yaml
+++ b/charts/hermes-agents/templates/deployment.yaml
@@ -40,8 +40,8 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.command }}
-          command:
+          {{- with .Values.args }}
+          args:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:

--- a/charts/hermes-agents/values.yaml
+++ b/charts/hermes-agents/values.yaml
@@ -10,8 +10,9 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-# Container command. Hermes documents `gateway run` as the default entrypoint.
-command:
+# Arguments passed to the image entrypoint (`hermes`). Hermes documents
+# `gateway run` as the default for a long-running gateway pod.
+args:
   - gateway
   - run
 


### PR DESCRIPTION
## Summary

New `charts/hermes-agents` chart that deploys [Hermes Agent](https://hermes-agent.nousresearch.com) (`nousresearch/hermes-agent`) as a long-running gateway pod.

- **Deployment** running `hermes gateway run` with `strategy: Recreate` (RWO-safe).
- **Service** (`service.enabled`) exposing the gateway on `8642`, plus the dashboard on `9119` when `dashboard.enabled=true`.
- **Ingress** matching the standard `className` / `annotations` / `hosts[]` / `tls[]` shape used by the `homepage` chart.
- **PersistentVolumeClaim** mounted at `/opt/data` — the single source of truth for all Hermes state (config, OAuth tokens, conversation history, skills, memories).

Credential bootstrap (Anthropic OAuth, Discord token, MCP servers, web search backends) happens via `kubectl exec` into the running pod — anything Hermes writes to `/opt/data` survives pod restarts.

## Changes between 0.1.0 → 0.1.1

Fixed the container spec: the image's ENTRYPOINT is `hermes`, so `gateway run` are CMD args, not the command. Using `command:` in 0.1.0 replaced the ENTRYPOINT and caused kubelet to try to exec a non-existent `gateway` binary directly. Renamed the values key `command` → `args` to match.

## Test plan

- [ ] `helm template charts/hermes-agents` renders cleanly with defaults.
- [ ] `helm template charts/hermes-agents -f tenant-values.yaml` renders the ingress with the expected `className`, `annotations`, `hosts`, and `tls` blocks.
- [ ] Pod reaches `Running` (no more `executable file not found: "gateway"`).
- [ ] `kubectl exec -it deploy/<release>-hermes-agents -- hermes setup` succeeds and persists across pod restarts.
- [ ] Ingress serves the gateway over TLS at the configured host.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LYfU9BunQGbCpCnceUR4tv)_