### PR TITLE
Add mdl helm chart for apple-music-downloader and wrapper

### DIFF
--- a/charts/mdl/.helmignore
+++ b/charts/mdl/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/mdl/Chart.yaml
+++ b/charts/mdl/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: mdl
+description: A Helm chart for apple-music-downloader and its wrapper decryption dependency
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"

--- a/charts/mdl/templates/mdl-deployment.yaml
+++ b/charts/mdl/templates/mdl-deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mdl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mdl
+  template:
+    metadata:
+      labels:
+        app: mdl
+    spec:
+      containers:
+      - image: {{ .Values.mdl.image }}
+        imagePullPolicy: {{ .Values.mdl.imagePullPolicy }}
+        name: mdl
+        ports:
+        - containerPort: {{ .Values.mdl.port }}
+          protocol: TCP
+          name: http
+        env:
+        # Connection details for the wrapper decryption dependency.
+        - name: WRAPPER_HOST
+          value: mdl-wrapper-svc
+        - name: WRAPPER_DECRYPT_PORT
+          value: {{ .Values.wrapper.decryptPort | quote }}
+        - name: WRAPPER_M3U8_PORT
+          value: {{ .Values.wrapper.m3u8Port | quote }}
+        - name: WRAPPER_ACCOUNT_PORT
+          value: {{ .Values.wrapper.accountPort | quote }}
+        volumeMounts:
+        - name: downloads
+          mountPath: {{ .Values.mdl.mountPath }}
+          {{- with .Values.mdl.nfs.subPath }}
+          subPath: {{ . }}
+          {{- end }}
+        {{- with .Values.mdl.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      volumes:
+        - name: downloads
+          nfs:
+            server: {{ .Values.mdl.nfs.server }}
+            path: {{ .Values.mdl.nfs.path }}
+            readOnly: {{ .Values.mdl.nfs.readOnly }}
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: mdl-svc
+spec:
+  type: ClusterIP
+  selector:
+    app: mdl
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: {{ .Values.mdl.port }}

--- a/charts/mdl/templates/wrapper-deployment.yaml
+++ b/charts/mdl/templates/wrapper-deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mdl-wrapper
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mdl-wrapper
+  template:
+    metadata:
+      labels:
+        app: mdl-wrapper
+    spec:
+      containers:
+      - image: {{ .Values.wrapper.image }}
+        imagePullPolicy: {{ .Values.wrapper.imagePullPolicy }}
+        name: wrapper
+        {{- if .Values.wrapper.privileged }}
+        securityContext:
+          privileged: true
+        {{- end }}
+        env:
+        - name: args
+          value: {{ .Values.wrapper.args | quote }}
+        ports:
+        - containerPort: {{ .Values.wrapper.decryptPort }}
+          protocol: TCP
+          name: decrypt
+        - containerPort: {{ .Values.wrapper.m3u8Port }}
+          protocol: TCP
+          name: m3u8
+        - containerPort: {{ .Values.wrapper.accountPort }}
+          protocol: TCP
+          name: account
+        volumeMounts:
+        - name: wrapper-data
+          mountPath: {{ .Values.wrapper.storage.mountPath }}
+        {{- with .Values.wrapper.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      volumes:
+        - name: wrapper-data
+          persistentVolumeClaim:
+            claimName: mdl-wrapper-data
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: mdl-wrapper-svc
+spec:
+  type: ClusterIP
+  selector:
+    app: mdl-wrapper
+  ports:
+  - name: decrypt
+    port: {{ .Values.wrapper.decryptPort }}
+    protocol: TCP
+    targetPort: {{ .Values.wrapper.decryptPort }}
+  - name: m3u8
+    port: {{ .Values.wrapper.m3u8Port }}
+    protocol: TCP
+    targetPort: {{ .Values.wrapper.m3u8Port }}
+  - name: account
+    port: {{ .Values.wrapper.accountPort }}
+    protocol: TCP
+    targetPort: {{ .Values.wrapper.accountPort }}

--- a/charts/mdl/templates/wrapper-pvc.yaml
+++ b/charts/mdl/templates/wrapper-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mdl-wrapper-data
+spec:
+  accessModes:
+    - {{ .Values.wrapper.storage.accessMode }}
+  storageClassName: {{ .Values.wrapper.storage.storageClassName }}
+  resources:
+    requests:
+      storage: {{ .Values.wrapper.storage.size }}

--- a/charts/mdl/values.yaml
+++ b/charts/mdl/values.yaml
@@ -1,0 +1,52 @@
+# apple-music-downloader
+# https://github.com/zhaarey/apple-music-downloader
+# NOTE: the upstream image is a CLI. Swap `mdl.image` for an HTTP server image
+# when ready - the NFS download mount and wrapper wiring stay the same.
+mdl:
+  image: ghcr.io/zhaarey/apple-music-downloader:latest
+  imagePullPolicy: Always
+  # Port the (future) HTTP server listens on inside the container.
+  port: 8080
+  # Where downloads are written inside the container.
+  mountPath: /downloads
+  # NFS share holding the downloaded music.
+  nfs:
+    server: cp0.seifert.id
+    path: /mnt/hdd_huge/
+    subPath: applemusic
+    readOnly: false
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "1000m"
+
+# wrapper (decryption dependency)
+# https://github.com/WorldObservationLog/wrapper
+wrapper:
+  image: ghcr.io/worldobservationlog/wrapper:local
+  imagePullPolicy: Always
+  # Passed to the wrapper via the `args` env var. Bind to all interfaces so the
+  # downloader pod can reach the decrypt/m3u8/account services.
+  args: "-H 0.0.0.0"
+  # Service ports exposed by the wrapper.
+  decryptPort: 10020
+  m3u8Port: 20020
+  accountPort: 30020
+  # The wrapper emulates an Android device and needs a privileged container.
+  privileged: true
+  # Persistent storage for /app/rootfs/data (login state / device data).
+  storage:
+    size: 2Gi
+    storageClassName: nfs-fast
+    accessMode: ReadWriteOnce
+    mountPath: /app/rootfs/data
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "200m"
+    limits:
+      memory: "1Gi"
+      cpu: "2000m"


### PR DESCRIPTION
Deploys zhaarey/apple-music-downloader with an NFS download mount and
its WorldObservationLog/wrapper decryption dependency backed by a PVC.
Both container images are configurable via values, and the downloader is
wired to the wrapper service over the decrypt/m3u8/account ports.