### PR TITLE
Add cliproxyapi Helm chart

### DIFF
--- a/charts/cliproxyapi/.helmignore
+++ b/charts/cliproxyapi/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/cliproxyapi/Chart.yaml
+++ b/charts/cliproxyapi/Chart.yaml
@@ -1,0 +1,34 @@
+apiVersion: v2
+name: cliproxyapi
+description: A Helm chart for CLIProxyAPI - a proxy server exposing OpenAI/Gemini/Claude/Codex-compatible endpoints backed by multiple AI providers
+home: https://github.com/router-for-me/CLIProxyAPI
+sources:
+  - https://github.com/router-for-me/CLIProxyAPI
+keywords:
+  - ai
+  - proxy
+  - openai
+  - gemini
+  - claude
+  - codex
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v7.2.48"

--- a/charts/cliproxyapi/README.md
+++ b/charts/cliproxyapi/README.md
@@ -1,0 +1,64 @@
+# CLIProxyAPI
+
+A Helm chart for [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) — a proxy
+server that exposes OpenAI/Gemini/Claude/Codex-compatible endpoints backed by multiple
+AI provider accounts.
+
+## Installing
+
+```sh
+helm install my-cliproxyapi ./charts/cliproxyapi
+```
+
+## Configuration
+
+The application's `config.yaml` is generated from the `config` value and mounted into the
+container at `/CLIProxyAPI/config.yaml`. Any key from CLIProxyAPI's
+[`config.example.yaml`](https://github.com/router-for-me/CLIProxyAPI/blob/main/config.example.yaml)
+may be added under `config`.
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `replicaCount` | `1` | Number of pod replicas. |
+| `image.repository` | `eceasy/cli-proxy-api` | Container image repository. |
+| `image.tag` | `""` | Image tag. Defaults to the chart `appVersion`. |
+| `image.pullPolicy` | `IfNotPresent` | Image pull policy. |
+| `service.type` | `ClusterIP` | Kubernetes Service type. |
+| `service.port` | `8317` | Service port. |
+| `ingress.enabled` | `false` | Enable an Ingress resource. |
+| `ingress.className` | `""` | IngressClass name. |
+| `ingress.annotations` | `{}` | Annotations for the Ingress. |
+| `ingress.hosts` | see `values.yaml` | Host and path rules. |
+| `ingress.tls` | `[]` | TLS configuration. |
+| `persistence.enabled` | `false` | Create/mount a PVC for the auth directory. |
+| `persistence.existingClaim` | `""` | Use an existing PVC instead of creating one. |
+| `persistence.storageClass` | `""` | StorageClass for the PVC (`"-"` disables dynamic provisioning). |
+| `persistence.accessModes` | `[ReadWriteOnce]` | PVC access modes. |
+| `persistence.size` | `1Gi` | PVC size. |
+| `persistence.mountPath` | `/root/.cli-proxy-api` | Mount path; keep in sync with `config.auth-dir`. |
+| `resources` | `{}` | Pod resource requests/limits. |
+| `config` | see `values.yaml` | Contents of the application `config.yaml`. |
+
+### Persistence
+
+CLIProxyAPI stores OAuth tokens and per-credential state in its auth directory
+(`config.auth-dir`, default `/root/.cli-proxy-api`). Enable `persistence` so this data
+survives pod restarts, and keep `persistence.mountPath` and `config.auth-dir` pointing at
+the same path.
+
+### Ingress
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: cliproxyapi.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: cliproxyapi-tls
+      hosts:
+        - cliproxyapi.example.com
+```

--- a/charts/cliproxyapi/templates/NOTES.txt
+++ b/charts/cliproxyapi/templates/NOTES.txt
@@ -1,0 +1,35 @@
+CLIProxyAPI has been deployed.
+
+{{- if .Values.ingress.enabled }}
+
+It is reachable through the configured ingress at:
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+
+Get the application URL by running these commands:
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "cliproxyapi.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+Get the application URL by running these commands:
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cliproxyapi.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+
+Get the application URL by running these commands:
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "cliproxyapi.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+  echo "Visit http://127.0.0.1:{{ .Values.service.port }} to use CLIProxyAPI"
+{{- end }}
+
+{{- if not .Values.persistence.enabled }}
+
+WARNING: Persistence is disabled. OAuth tokens and credential state written to
+"{{ index .Values.config "auth-dir" }}" will be lost when the pod restarts. Set
+persistence.enabled=true to retain them across restarts.
+{{- end }}

--- a/charts/cliproxyapi/templates/_helpers.tpl
+++ b/charts/cliproxyapi/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cliproxyapi.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cliproxyapi.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cliproxyapi.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cliproxyapi.labels" -}}
+helm.sh/chart: {{ include "cliproxyapi.chart" . }}
+{{ include "cliproxyapi.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cliproxyapi.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cliproxyapi.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cliproxyapi.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cliproxyapi.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name of the PersistentVolumeClaim to use for the auth directory.
+*/}}
+{{- define "cliproxyapi.pvcName" -}}
+{{- if .Values.persistence.existingClaim }}
+{{- .Values.persistence.existingClaim }}
+{{- else }}
+{{- include "cliproxyapi.fullname" . }}
+{{- end }}
+{{- end }}

--- a/charts/cliproxyapi/templates/configmap.yaml
+++ b/charts/cliproxyapi/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cliproxyapi.fullname" . }}
+  labels:
+    {{- include "cliproxyapi.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- toYaml .Values.config | nindent 4 }}

--- a/charts/cliproxyapi/templates/deployment.yaml
+++ b/charts/cliproxyapi/templates/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cliproxyapi.fullname" . }}
+  labels:
+    {{- include "cliproxyapi.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "cliproxyapi.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "cliproxyapi.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "cliproxyapi.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.config.port | default 8317 }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /CLIProxyAPI/config.yaml
+              subPath: config.yaml
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "cliproxyapi.fullname" . }}
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "cliproxyapi.pvcName" . }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/cliproxyapi/templates/ingress.yaml
+++ b/charts/cliproxyapi/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "cliproxyapi.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "cliproxyapi.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/cliproxyapi/templates/pvc.yaml
+++ b/charts/cliproxyapi/templates/pvc.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "cliproxyapi.pvcName" . }}
+  labels:
+    {{- include "cliproxyapi.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/cliproxyapi/templates/service.yaml
+++ b/charts/cliproxyapi/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cliproxyapi.fullname" . }}
+  labels:
+    {{- include "cliproxyapi.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "cliproxyapi.selectorLabels" . | nindent 4 }}

--- a/charts/cliproxyapi/templates/serviceaccount.yaml
+++ b/charts/cliproxyapi/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cliproxyapi.serviceAccountName" . }}
+  labels:
+    {{- include "cliproxyapi.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/cliproxyapi/values.yaml
+++ b/charts/cliproxyapi/values.yaml
@@ -1,0 +1,126 @@
+# Default values for cliproxyapi.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: eceasy/cli-proxy-api
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #     - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 8317
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: cliproxyapi.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: cliproxyapi-tls
+  #    hosts:
+  #      - cliproxyapi.local
+
+# Persistence for the authentication directory (auth-dir), where OAuth tokens
+# and per-credential state are stored and must survive pod restarts.
+persistence:
+  enabled: false
+  # Use an existing PersistentVolumeClaim instead of creating one.
+  existingClaim: ""
+  # storageClass: "-"
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 1Gi
+  annotations: {}
+  # Path inside the container where the volume is mounted. Must match
+  # config."auth-dir" below so credentials are written to the persistent volume.
+  mountPath: /root/.cli-proxy-api
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube.
+  # limits:
+  #   cpu: 500m
+  #   memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 15
+
+readinessProbe:
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Application configuration rendered into a ConfigMap and mounted at
+# /CLIProxyAPI/config.yaml. Any key from CLIProxyAPI's config.example.yaml may
+# be added here. See https://github.com/router-for-me/CLIProxyAPI for the full
+# reference.
+config:
+  # Server host/interface to bind to. Empty binds all interfaces.
+  host: ""
+  # Server port. Should match service.port and the container port.
+  port: 8317
+  # Authentication directory. Keep this in sync with persistence.mountPath so
+  # OAuth tokens land on the persistent volume.
+  auth-dir: /root/.cli-proxy-api
+  # Enable debug logging.
+  debug: false
+  # API keys clients must present to authenticate against this proxy.
+  api-keys: []
+  #   - "your-api-key-1"
+  remote-management:
+    # Whether to allow remote (non-localhost) management access.
+    allow-remote: false
+    # Management key. Leave empty to disable the Management API entirely.
+    secret-key: ""


### PR DESCRIPTION
Add a Helm chart for CLIProxyAPI (router-for-me/CLIProxyAPI), a proxy
server exposing OpenAI/Gemini/Claude/Codex-compatible endpoints.

The chart follows standard Helm conventions for values naming and
supports:
- Configurable persistence (PVC) for the auth directory where OAuth
  tokens and credential state are stored, with existingClaim support.
- Configurable ingress (className, annotations, hosts, TLS).
- Application config rendered into a ConfigMap and mounted at
  /CLIProxyAPI/config.yaml, with a config checksum annotation to roll
  the deployment on config changes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LsiJTL5AeL4CJVw8TLFEYu